### PR TITLE
1. use more concrete nft_name.

### DIFF
--- a/free_mint_nft.py
+++ b/free_mint_nft.py
@@ -103,7 +103,7 @@ def get_info_by_hash(hash):
                 function_name = re.findall(r"Function: (.*?)\(", text.text)
                 if function_name:
                     function_name = function_name[0]
-                    nft_name = soup.find('span', class_='hash-tag text-truncate mr-1').text
+                    nft_name = soup.find('span', class_='hash-tag text-truncate mr-1')["title"]
                     return {"status":True, "mint_count":mint_count, "function_name":function_name, "nft_name":nft_name}
                 else:
                     print_red(f"[get_info_by_hash] error: function_name not found , probably not open source , hash: {hash}")


### PR DESCRIPTION
因为有些nft名字过长之后，原写法提取的nft名字不完整，导致黑名单过滤不起效。新写法可以提取完整的nft名字。